### PR TITLE
fix: CI pipeline deps + pin qwen-vl-utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,23 +31,29 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-cov flake8 black isort
-        pip install torch --index-url https://download.pytorch.org/whl/cpu
-        pip install pillow pyyaml numpy opencv-python-headless python-magic
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+        # Install project deps, skip flash-attn (requires CUDA)
+        pip install transformers==4.47.1 accelerate==1.2.1 qwen-vl-utils==0.0.14
+        pip install bitsandbytes==0.45.0
+        pip install fastapi==0.115.6 uvicorn==0.34.0 python-multipart==0.0.19
+        pip install streamlit==1.41.1
+        pip install pillow==11.1.0 pyyaml==6.0.2 requests==2.32.3 numpy==1.26.4 pandas==2.2.3
+        pip install opencv-python-headless==4.10.0.84
     
     - name: Lint with flake8
       run: |
-        # Остановка при синтаксических ошибках
+        # Stop on syntax errors
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # Предупреждения (не останавливают сборку)
+        # Warnings (non-blocking)
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
     
     - name: Check formatting with black
       run: |
-        black --check --diff . || echo "::warning::Black formatting issues found (non-blocking)"
+        black --check --diff .
     
     - name: Check imports with isort
       run: |
-        isort --check-only --diff . || echo "::warning::isort import ordering issues found (non-blocking)"
+        isort --check-only --diff .
     
     - name: Run tests
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ transformers==4.47.1
 accelerate==1.2.1
 
 # VLM specific
-qwen-vl-utils
+qwen-vl-utils==0.0.14
 flash-attn==2.7.3
 bitsandbytes==0.45.0
 


### PR DESCRIPTION
## Изменения

### `.github/workflows/ci.yml` (closes #68)

**Deps:**
- Добавлены `transformers==4.47.1`, `accelerate==1.2.1`, `qwen-vl-utils==0.0.14`
- Добавлены `bitsandbytes`, `fastapi`, `uvicorn`, `streamlit`, `pandas` и др.
- `flash-attn` пропущен (требует CUDA, недоступен в CI)
- `torch` устанавливается с `torchvision torchaudio` (CPU)

**Linting:**
- `black --check --diff .` — теперь **blocking** (без `|| echo`)
- `isort --check-only --diff .` — теперь **blocking**
- flake8 syntax errors — blocking, warnings — non-blocking (как было)

### `requirements.txt` (closes #69)

- `qwen-vl-utils` → `qwen-vl-utils==0.0.14`

## Риски

⚠️ **black/isort теперь blocking** — если код не отформатирован, CI упадёт. Это правильно, но может потребовать `black .` + `isort .` перед пушем.